### PR TITLE
fix: Adding shas instead of latest tags in guardrails repo

### DIFF
--- a/guardrails/orchestrator/generator/llm_model_container.yaml
+++ b/guardrails/orchestrator/generator/llm_model_container.yaml
@@ -47,7 +47,7 @@ spec:
             claimName: llm-models-claim
       initContainers:
         - name: download-model
-          image: quay.io/rh-ee-mmisiura/llm-downloader-bootstrap:latest
+          image: quay.io/rh-ee-mmisiura/llm-downloader-bootstrap@sha256:0034bebe904eabe40315463702275c6d33a0f22404a59b2c2d9e4d25a6cd750f
           securityContext:
             fsGroup: 1001
           command:
@@ -74,7 +74,7 @@ spec:
               value: THEACCESSKEY
             - name: MINIO_SECRET_KEY
               value: THESECRETKEY
-          image: quay.io/trustyai/modelmesh-minio-examples:latest
+          image: quay.io/trustyai/modelmesh-minio-examples@sha256:65cb22335574b89af15d7409f62feffcc52cc0e870e9419d63586f37706321a5
           name: minio-llm
           securityContext:
             allowPrivilegeEscalation: false

--- a/guardrails/orchestrator/generator/llm_sr.yaml
+++ b/guardrails/orchestrator/generator/llm_sr.yaml
@@ -24,7 +24,7 @@ spec:
       env:
         - name: HF_HOME
           value: /tmp/hf_home
-      image: 'quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9:0.2'
+      image: 'quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9@sha256:d680ff8becb6bbaf83dfee7b2d9b8a2beb130db7fd5aa7f9a6d8286a58cebbfd'
       name: kserve-container
       ports:
         - containerPort: 8032

--- a/guardrails/orchestrator/gorch_cm.yaml
+++ b/guardrails/orchestrator/gorch_cm.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: guardrails-orchestrator-config
 data:
-  regexDetectorImage: 'quay.io/csantiago/regex-detector:latest'
-  vllmGatewayImage: 'quay.io/csantiago/vllm-orchestrator-gateway:latest'
+  regexDetectorImage: 'quay.io/csantiago/regex-detector@sha256:2dbfa4680938a97d0e0cac75049c43687ad163666cf2c6ddc37643c4f516d144'
+  vllmGatewayImage: 'quay.io/csantiago/vllm-orchestrator-gateway@sha256:493ac4679d50db9c2c59967dcaa6737a995cd19f319727f33c40f159db6817db'


### PR DESCRIPTION
For diconnected we need shas instead of latest tags